### PR TITLE
Node ready

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,107 @@
+'use strict';
+
+var regexs = {
+  en: "[A-Za-z]+",
+  ko: "[가-힣]+",
+  jp: "[\u3040-\u309F\u30A0-\u30FF]+",
+  cn: "[\u4E00-\u9FBF]+",
+  num: "[0-9]+",
+  punct: "[\(\).,“”\-]|&amp;|&lt;|&gt;+"
+}
+
+var Multilingual = function(params) {
+  this.containers = params.containers;
+  this.configuration = params.configuration;
+
+  this.init();
+}
+
+Multilingual.prototype.init = function() {
+  var finalRegex = this.composeRegex();
+  var configuration = this.configuration;
+
+  for (var i = 0, len = this.containers.length; i < len; i++){
+    var container = this.containers[i];
+    container.innerHTML = container.innerHTML.replace(finalRegex, function(){
+      for (var i = 1; i < arguments.length; i++) {
+        if (arguments[i] != undefined) {
+          var config = configuration[i - 1];
+          var className;
+
+          if (typeof config == "string"){
+            className = "ml-" + config;
+          } else {
+            className = config.className;
+          }
+
+          return "<span class='" + className + "'>" + arguments[i] + "</span>";
+        }
+      }
+    });
+  }
+};
+
+Multilingual.prototype.escapeRegexStr = function(str) {
+  return str.replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, "\\$&");
+}
+
+Multilingual.prototype.computeCustomRegex = function(charset) {
+  charset = this.escapeRegexStr(charset);
+
+  var htmlEscapedChars = [];
+  var finalStr = "";
+
+  if (charset.match(/\&/) != null || charset.match(/\&amp;/) != null){
+    htmlEscapedChars.push("&amp;");
+    charset = charset.replace(/\&/, "");
+    charset = charset.replace(/\&amp;/, "");
+  }
+
+  if (charset.match(/</) != null || charset.match(/\&lt;/) != null){
+    htmlEscapedChars.push("&lt;");
+    charset = charset.replace(/</, "");
+    charset = charset.replace(/\&lt;/, "");
+  }
+
+  if (charset.match(/>/) != null || charset.match(/\&gt;/) != null){
+    htmlEscapedChars.push("&gt;");
+    charset = charset.replace(/>/, "");
+    charset = charset.replace(/\&gt;/, "");
+  }
+
+  if (charset.match(/>/) != null || charset.match(/\&emdash;/) != null){
+    htmlEscapedChars.push("&emdash;");
+    charset = charset.replace(/>/, "");
+    charset = charset.replace(/\&emdash;/, "");
+  }
+
+  if (htmlEscapedChars.length > 0) {
+    finalStr = "([" + charset + "]|" + htmlEscapedChars.join("|") + "+)";
+  } else {
+    finalStr = "([" + charset + "]+)";
+  }
+  return finalStr;
+}
+
+
+Multilingual.prototype.composeRegex = function(){
+  var finalRegexStr = "(\?![^<>&]*>)";
+
+  for (var i = 0, len = this.configuration.length; i < len; i++){
+    var config = this.configuration[i];
+
+    if (typeof config == "string"){
+      finalRegexStr += "(" + regexs[config] + ")";
+    } else {
+      finalRegexStr += this.computeCustomRegex(config.charset);
+    }
+
+    if (i < this.configuration.length - 1) {
+      finalRegexStr += "|";
+    }
+  }
+
+  return new RegExp(finalRegexStr, "gm");
+}
+
+module.exports = Multilingual;

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "multilingual.js",
+  "name": "multilingual",
   "version": "0.0.1",
   "description": "Micro screen typography for CJK typesetting",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -3,9 +3,6 @@
   "version": "0.0.1",
   "description": "Micro screen typography for CJK typesetting",
   "main": "index.js",
-  "scripts": {
-    "test": "webpack-dev-server"
-  },
   "repository": {
     "type": "git",
     "url": "git+ssh://git@github.com/wonyoungso/multilingual.js.git"
@@ -17,17 +14,6 @@
     "composite",
     "fonts"
   ],
-  "devDependencies": {
-    "webpack": "^1.9.11",
-    "expose-loader": "~0.7.1",
-    "mocha-loader": "~0.7.1",
-    "mocha": "~2.0.1",
-    "chai": "~3.5.0",
-    "webpack-dev-server": "^1.9.0",
-    "lodash": "~4.2.0",
-    "jquery": "~2.1.4",
-    "backbone-events-standalone": "~0.2.7"
-  },
   "author": "Wonyoung So <mail@wonyoung.so> (http://wonyoung.so/), E Roon Kang <eroonkang@gmail.com>",
   "license": "MIT",
   "bugs": {


### PR DESCRIPTION
npm 패키지로 기능할 수 있도록 Multilingual 객체를 다시 작성합니다.
### 1. package.json 정리

1-1. npm 권고에 맞게 패키지 이름에 `.js` 제거
1-2. 현재 당장 필요 없는 `devDependency` 제거. 정말 npm 상으로 필요할때 넣기.
### 2. `index.js` 작성하여, 해당 파일을 `import` 하여, `Multilingual` 객체 사용할 수 있게 하도록 함.

다른 webpack 기반 프로젝트에서 local npm 모듈로 로드하여, 잘 동작함을 확인함.

응용 코드 작성 사례
<img width="776" alt="2016-05-01 4 56 21" src="https://cloud.githubusercontent.com/assets/1055213/14940756/afbba486-0fbd-11e6-8d9e-786e3fee5854.png">

결과
<img width="599" alt="2016-05-01 4 56 10" src="https://cloud.githubusercontent.com/assets/1055213/14940757/c0a194b8-0fbd-11e6-89b7-11c40b4229d8.png">
### 3. 그외

prototype 자체 정의 대신, prototype 의 각 메소드를 정의하는 방식으로.(이게 사이드 이펙트가 없다나.)
패키지 이름과 맞추기 위해 `MultiLingual` 에서 `Multilingual` 로 객체 이름 변경.
변수 컨벤션 JS 에 맞게 camelCase 로.
### 4. 앞으로 해볼 만한 것.

이 npm 패키지를 사용하여 다른 응용 패키지를 만들수 있도록, 기능에서 DOM replace을 빼내기.
(이부분은 좀 이야기가 필요할 수도)
예시 코드 좀더 robust 하게. (이런데선 webpack 이 필요할지도)
npm 못쓰는 사람들에게 코드 제공하는법 찾아보기. (UMD build)
